### PR TITLE
Track upstream changes (update to 23.1.x, fix usage of plist_options)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,3 +1,5 @@
+name: CI
+
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
@@ -10,7 +12,7 @@ on:
 
 jobs:
   cockroach-test:
-    name: Cockroach formula tests
+    name: cockroach formula tests
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v3
@@ -19,7 +21,7 @@ jobs:
     - name: test cockroach formula
       run: brew test ./Formula/cockroach.rb
   cockroach-sql-test:
-    name: Cockroach-sql formula tests
+    name: cockroach-sql formula tests
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v3
@@ -27,3 +29,12 @@ jobs:
       run: brew install ./Formula/cockroach-sql.rb
     - name: test cockroach formula
       run: brew test ./Formula/cockroach-sql.rb
+  ccloud-test:
+    name: ccloud formula tests
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install ccloud formula
+      run: brew install ./Formula/ccloud.rb
+    - name: test ccloud formula
+      run: brew test ./Formula/ccloud.rb

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,29 @@
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  cockroach-test:
+    name: Cockroach formula tests
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install cockroach formula
+      run: brew install ./Formula/cockroach.rb
+    - name: test cockroach formula
+      run: brew test ./Formula/cockroach.rb
+  cockroach-sql-test:
+    name: Cockroach-sql formula tests
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install cockroach-sql formula
+      run: brew install ./Formula/cockroach-sql.rb
+    - name: test cockroach formula
+      run: brew test ./Formula/cockroach-sql.rb

--- a/Formula/ccloud.rb
+++ b/Formula/ccloud.rb
@@ -5,8 +5,17 @@ class Ccloud < Formula
   desc "CockroachDB Cloud CLI"
   homepage "https://www.cockroachlabs.com"
   version "0.3.7"
-  url "https://binaries.cockroachdb.com/ccloud/ccloud_darwin-amd64_0.3.7.tar.gz"
-  sha256 "a0999ec88afb762da7686797d0ac910c38ba13851c1e10946277e28aa0eb3051"
+
+  on_macos do
+    on_intel do
+      url "https://binaries.cockroachdb.com/ccloud/ccloud_darwin-amd64_0.3.7.tar.gz"
+      sha256 "a0999ec88afb762da7686797d0ac910c38ba13851c1e10946277e28aa0eb3051"
+    end
+    on_arm do
+      url "https://binaries.cockroachdb.com/ccloud/ccloud_darwin-arm64_0.3.7.tar.gz"
+      sha256 "0722bdc9713174c2bc03702e9ab6f7da6216ea8a2421c9015075da8288781ff3"
+    end
+  end
 
   def install
     bin.install "ccloud"

--- a/Formula/ccloud.rb
+++ b/Formula/ccloud.rb
@@ -4,16 +4,16 @@
 class Ccloud < Formula
   desc "CockroachDB Cloud CLI"
   homepage "https://www.cockroachlabs.com"
-  version "0.3.7"
+  version "0.4.9"
 
   on_macos do
     on_intel do
-      url "https://binaries.cockroachdb.com/ccloud/ccloud_darwin-amd64_0.3.7.tar.gz"
-      sha256 "a0999ec88afb762da7686797d0ac910c38ba13851c1e10946277e28aa0eb3051"
+      url "https://binaries.cockroachdb.com/ccloud/ccloud_darwin-amd64_0.4.9.tar.gz"
+      sha256 "68b762bdcc82392356d3c73b12d809e697d0701c54227bd6a8516d80ab86ce2f"
     end
     on_arm do
-      url "https://binaries.cockroachdb.com/ccloud/ccloud_darwin-arm64_0.3.7.tar.gz"
-      sha256 "0722bdc9713174c2bc03702e9ab6f7da6216ea8a2421c9015075da8288781ff3"
+      url "https://binaries.cockroachdb.com/ccloud/ccloud_darwin-arm64_0.4.9.tar.gz"
+      sha256 "a7be7d58cbc944316234ab5f8f878904b7ea5b765b7785058e9b420088514838"
     end
   end
 
@@ -23,7 +23,7 @@ class Ccloud < Formula
 
   test do
     output = shell_output("#{bin}/ccloud version", 0)
-    assert_match "ccloud 0.3.7", output
+    assert_match "ccloud 0.4.9", output
   end
 end
 

--- a/Formula/cockroach-sql.rb
+++ b/Formula/cockroach-sql.rb
@@ -4,15 +4,15 @@
 class CockroachSql < Formula
   desc "Distributed SQL database shell"
   homepage "https://www.cockroachlabs.com"
-  version "22.2.3"
+  version "22.2.4"
   on_macos do
     on_intel do
-      url "https://binaries.cockroachdb.com/cockroach-sql-v22.2.3.darwin-10.9-amd64.tgz"
-      sha256 "3d18eea41824aa5a6b70eb9043f29d84f54bf14a7317cc9f5a71086a20964bea"
+      url "https://binaries.cockroachdb.com/cockroach-sql-v22.2.4.darwin-10.9-amd64.tgz"
+      sha256 "b79533d62a812a5e47152f984cb027254a5e47144a0fc5d7b99c44833e31dd73"
     end
     on_arm do
-      url "https://binaries.cockroachdb.com/cockroach-sql-v22.2.3.darwin-11.0-arm64.tgz"
-      sha256 "28ac8ad22a70f0d52ccaff189cac670103c3e8a7e01bb39f010d7398d3512c94"
+      url "https://binaries.cockroachdb.com/cockroach-sql-v22.2.4.darwin-11.0-arm64.tgz"
+      sha256 "2476e54242d5177bfabe46a3dddaa66a963e94fa0643385583c9a00c51963968"
     end
   end
 
@@ -22,7 +22,7 @@ class CockroachSql < Formula
 
   test do
     output = shell_output("#{bin}/cockroach-sql --version", 0)
-    assert_match "22.2.3", output
+    assert_match "22.2.4", output
   end
 
 end

--- a/Formula/cockroach-sql.rb
+++ b/Formula/cockroach-sql.rb
@@ -4,15 +4,15 @@
 class CockroachSql < Formula
   desc "Distributed SQL database shell"
   homepage "https://www.cockroachlabs.com"
-  version "22.2.8"
+  version "22.2.9"
   on_macos do
     on_intel do
-      url "https://binaries.cockroachdb.com/cockroach-sql-v22.2.8.darwin-10.9-amd64.tgz"
-      sha256 "1d143178fddca0a5c8783116d89bb04249d09405c8be9054ec4c53e2646a8b8e"
+      url "https://binaries.cockroachdb.com/cockroach-sql-v22.2.9.darwin-10.9-amd64.tgz"
+      sha256 "6ef9f552164f858b1bd47ea18102d4e4ef865c9a1e00f0e8a07821ef61b59b04"
     end
     on_arm do
-      url "https://binaries.cockroachdb.com/cockroach-sql-v22.2.8.darwin-11.0-arm64.tgz"
-      sha256 "1ae6d35542198b856113ca35f5e07f932ce51c44f718e015f455b43691a10ea5"
+      url "https://binaries.cockroachdb.com/cockroach-sql-v22.2.9.darwin-11.0-arm64.tgz"
+      sha256 "02b6e5f1f5802de97e06b9f57aaa02ef7eead0db18ec14a00f8856212554751c"
     end
   end
 
@@ -22,7 +22,7 @@ class CockroachSql < Formula
 
   test do
     output = shell_output("#{bin}/cockroach-sql --version", 0)
-    assert_match "22.2.8", output
+    assert_match "22.2.9", output
   end
 
 end

--- a/Formula/cockroach-sql.rb
+++ b/Formula/cockroach-sql.rb
@@ -4,15 +4,15 @@
 class CockroachSql < Formula
   desc "Distributed SQL database shell"
   homepage "https://www.cockroachlabs.com"
-  version "22.2.5"
+  version "22.2.6"
   on_macos do
     on_intel do
-      url "https://binaries.cockroachdb.com/cockroach-sql-v22.2.5.darwin-10.9-amd64.tgz"
-      sha256 "aa6ad25fb98b99f7bfea5b07534e5c1c47683c02054de357e62c80db43542a7b"
+      url "https://binaries.cockroachdb.com/cockroach-sql-v22.2.6.darwin-10.9-amd64.tgz"
+      sha256 "aaff0691ab9ee50d304cb4909a34bbea9eef1e216ab53457ba825f53e5bf7001"
     end
     on_arm do
-      url "https://binaries.cockroachdb.com/cockroach-sql-v22.2.5.darwin-11.0-arm64.tgz"
-      sha256 "9f456120d48cdf2c71b5c001a93688501b05e0adfa081ae92af12f2f74b75b5d"
+      url "https://binaries.cockroachdb.com/cockroach-sql-v22.2.6.darwin-11.0-arm64.tgz"
+      sha256 "4fccbef4c092f036a92a2bc82c265a0730baa86cc1cd3c8f59f7426491476afb"
     end
   end
 
@@ -22,7 +22,7 @@ class CockroachSql < Formula
 
   test do
     output = shell_output("#{bin}/cockroach-sql --version", 0)
-    assert_match "22.2.5", output
+    assert_match "22.2.6", output
   end
 
 end

--- a/Formula/cockroach-sql.rb
+++ b/Formula/cockroach-sql.rb
@@ -4,15 +4,15 @@
 class CockroachSql < Formula
   desc "Distributed SQL database shell"
   homepage "https://www.cockroachlabs.com"
-  version "23.1.2"
+  version "23.1.3"
   on_macos do
     on_intel do
-      url "https://binaries.cockroachdb.com/cockroach-sql-v23.1.2.darwin-10.9-amd64.tgz"
-      sha256 "37bfc55e625c9b5e52eaa1671d903cb3ef57c783587171ff610a8bb4a1b90abb"
+      url "https://binaries.cockroachdb.com/cockroach-sql-v23.1.3.darwin-10.9-amd64.tgz"
+      sha256 "76304051115824fa914f80f0a6426c7b481084a19396623a29406f089c5fcd69"
     end
     on_arm do
-      url "https://binaries.cockroachdb.com/cockroach-sql-v23.1.2.darwin-11.0-arm64.tgz"
-      sha256 "6047872c8e5cf2d9c70b915b727c82a091aa320e42fa998f12b0dd2d4cfe05f7"
+      url "https://binaries.cockroachdb.com/cockroach-sql-v23.1.3.darwin-11.0-arm64.tgz"
+      sha256 "ad0ebe1367a4ec7b2dc5593c4c511fa2320dcc62c389cbfccbd41c7a64991b56"
     end
   end
 
@@ -22,7 +22,7 @@ class CockroachSql < Formula
 
   test do
     output = shell_output("#{bin}/cockroach-sql --version", 0)
-    assert_match "23.1.2", output
+    assert_match "23.1.3", output
   end
 
 end

--- a/Formula/cockroach-sql.rb
+++ b/Formula/cockroach-sql.rb
@@ -4,15 +4,15 @@
 class CockroachSql < Formula
   desc "Distributed SQL database shell"
   homepage "https://www.cockroachlabs.com"
-  version "23.1.1"
+  version "23.1.2"
   on_macos do
     on_intel do
-      url "https://binaries.cockroachdb.com/cockroach-sql-v23.1.1.darwin-10.9-amd64.tgz"
-      sha256 "386dc01e49bad96ac298b2d5a5285ed4e1b741df62c6e89691df5b5f2d0221d6"
+      url "https://binaries.cockroachdb.com/cockroach-sql-v23.1.2.darwin-10.9-amd64.tgz"
+      sha256 "37bfc55e625c9b5e52eaa1671d903cb3ef57c783587171ff610a8bb4a1b90abb"
     end
     on_arm do
-      url "https://binaries.cockroachdb.com/cockroach-sql-v23.1.1.darwin-11.0-arm64.tgz"
-      sha256 "900d1e46bcb3f067e3fdb6ba38e1bd50a91fc4ef541d2145eb96490985dea485"
+      url "https://binaries.cockroachdb.com/cockroach-sql-v23.1.2.darwin-11.0-arm64.tgz"
+      sha256 "6047872c8e5cf2d9c70b915b727c82a091aa320e42fa998f12b0dd2d4cfe05f7"
     end
   end
 
@@ -22,7 +22,7 @@ class CockroachSql < Formula
 
   test do
     output = shell_output("#{bin}/cockroach-sql --version", 0)
-    assert_match "23.1.1", output
+    assert_match "23.1.2", output
   end
 
 end

--- a/Formula/cockroach-sql.rb
+++ b/Formula/cockroach-sql.rb
@@ -4,15 +4,15 @@
 class CockroachSql < Formula
   desc "Distributed SQL database shell"
   homepage "https://www.cockroachlabs.com"
-  version "23.1.3"
+  version "23.1.4"
   on_macos do
     on_intel do
-      url "https://binaries.cockroachdb.com/cockroach-sql-v23.1.3.darwin-10.9-amd64.tgz"
-      sha256 "76304051115824fa914f80f0a6426c7b481084a19396623a29406f089c5fcd69"
+      url "https://binaries.cockroachdb.com/cockroach-sql-v23.1.4.darwin-10.9-amd64.tgz"
+      sha256 "7d4f56c90e3385560ca929cc5f45434718f5837a222f0e5b3b16b9211ddddfa5"
     end
     on_arm do
-      url "https://binaries.cockroachdb.com/cockroach-sql-v23.1.3.darwin-11.0-arm64.tgz"
-      sha256 "ad0ebe1367a4ec7b2dc5593c4c511fa2320dcc62c389cbfccbd41c7a64991b56"
+      url "https://binaries.cockroachdb.com/cockroach-sql-v23.1.4.darwin-11.0-arm64.tgz"
+      sha256 "7ceb52c10113955c54d43c7d523297a2e38d5457109b3da8cd9d944e4b803cba"
     end
   end
 
@@ -22,7 +22,7 @@ class CockroachSql < Formula
 
   test do
     output = shell_output("#{bin}/cockroach-sql --version", 0)
-    assert_match "23.1.3", output
+    assert_match "23.1.4", output
   end
 
 end

--- a/Formula/cockroach-sql.rb
+++ b/Formula/cockroach-sql.rb
@@ -4,15 +4,15 @@
 class CockroachSql < Formula
   desc "Distributed SQL database shell"
   homepage "https://www.cockroachlabs.com"
-  version "22.2.3"
+  version "22.2.5"
   on_macos do
     on_intel do
-      url "https://binaries.cockroachdb.com/cockroach-sql-v22.2.3.darwin-10.9-amd64.tgz"
-      sha256 "3d18eea41824aa5a6b70eb9043f29d84f54bf14a7317cc9f5a71086a20964bea"
+      url "https://binaries.cockroachdb.com/cockroach-sql-v22.2.5.darwin-10.9-amd64.tgz"
+      sha256 "aa6ad25fb98b99f7bfea5b07534e5c1c47683c02054de357e62c80db43542a7b"
     end
     on_arm do
-      url "https://binaries.cockroachdb.com/cockroach-sql-v22.2.3.darwin-11.0-arm64.tgz"
-      sha256 "28ac8ad22a70f0d52ccaff189cac670103c3e8a7e01bb39f010d7398d3512c94"
+      url "https://binaries.cockroachdb.com/cockroach-sql-v22.2.5.darwin-11.0-arm64.tgz"
+      sha256 "9f456120d48cdf2c71b5c001a93688501b05e0adfa081ae92af12f2f74b75b5d"
     end
   end
 
@@ -22,7 +22,7 @@ class CockroachSql < Formula
 
   test do
     output = shell_output("#{bin}/cockroach-sql --version", 0)
-    assert_match "22.2.3", output
+    assert_match "22.2.5", output
   end
 
 end

--- a/Formula/cockroach-sql.rb
+++ b/Formula/cockroach-sql.rb
@@ -4,15 +4,15 @@
 class CockroachSql < Formula
   desc "Distributed SQL database shell"
   homepage "https://www.cockroachlabs.com"
-  version "22.2.9"
+  version "23.1.0"
   on_macos do
     on_intel do
-      url "https://binaries.cockroachdb.com/cockroach-sql-v22.2.9.darwin-10.9-amd64.tgz"
-      sha256 "6ef9f552164f858b1bd47ea18102d4e4ef865c9a1e00f0e8a07821ef61b59b04"
+      url "https://binaries.cockroachdb.com/cockroach-sql-v23.1.0.darwin-10.9-amd64.tgz"
+      sha256 "42687b024f6dc0427f4754ce70e8dc7624f38d9e342781f8376722bb94c1da67"
     end
     on_arm do
-      url "https://binaries.cockroachdb.com/cockroach-sql-v22.2.9.darwin-11.0-arm64.tgz"
-      sha256 "02b6e5f1f5802de97e06b9f57aaa02ef7eead0db18ec14a00f8856212554751c"
+      url "https://binaries.cockroachdb.com/cockroach-sql-v23.1.0.darwin-11.0-arm64.tgz"
+      sha256 "85c24b7728fdfab795d6df9703ee81e3824ad473d0b89f5ac428d8ea7d3bfe14"
     end
   end
 
@@ -22,7 +22,7 @@ class CockroachSql < Formula
 
   test do
     output = shell_output("#{bin}/cockroach-sql --version", 0)
-    assert_match "22.2.9", output
+    assert_match "23.1.0", output
   end
 
 end

--- a/Formula/cockroach-sql.rb
+++ b/Formula/cockroach-sql.rb
@@ -4,15 +4,15 @@
 class CockroachSql < Formula
   desc "Distributed SQL database shell"
   homepage "https://www.cockroachlabs.com"
-  version "22.2.7"
+  version "22.2.8"
   on_macos do
     on_intel do
-      url "https://binaries.cockroachdb.com/cockroach-sql-v22.2.7.darwin-10.9-amd64.tgz"
-      sha256 "b61943a3758b63e83c5a420ee5ca6aef5017260de26d55df46705bf12c67a08e"
+      url "https://binaries.cockroachdb.com/cockroach-sql-v22.2.8.darwin-10.9-amd64.tgz"
+      sha256 "1d143178fddca0a5c8783116d89bb04249d09405c8be9054ec4c53e2646a8b8e"
     end
     on_arm do
-      url "https://binaries.cockroachdb.com/cockroach-sql-v22.2.7.darwin-11.0-arm64.tgz"
-      sha256 "5084703331848581114d4778338ad387e448eff7d62493db999097380ecbe34d"
+      url "https://binaries.cockroachdb.com/cockroach-sql-v22.2.8.darwin-11.0-arm64.tgz"
+      sha256 "1ae6d35542198b856113ca35f5e07f932ce51c44f718e015f455b43691a10ea5"
     end
   end
 
@@ -22,7 +22,7 @@ class CockroachSql < Formula
 
   test do
     output = shell_output("#{bin}/cockroach-sql --version", 0)
-    assert_match "22.2.7", output
+    assert_match "22.2.8", output
   end
 
 end

--- a/Formula/cockroach-sql.rb
+++ b/Formula/cockroach-sql.rb
@@ -4,15 +4,15 @@
 class CockroachSql < Formula
   desc "Distributed SQL database shell"
   homepage "https://www.cockroachlabs.com"
-  version "22.2.4"
+  version "22.2.3"
   on_macos do
     on_intel do
-      url "https://binaries.cockroachdb.com/cockroach-sql-v22.2.4.darwin-10.9-amd64.tgz"
-      sha256 "b79533d62a812a5e47152f984cb027254a5e47144a0fc5d7b99c44833e31dd73"
+      url "https://binaries.cockroachdb.com/cockroach-sql-v22.2.3.darwin-10.9-amd64.tgz"
+      sha256 "3d18eea41824aa5a6b70eb9043f29d84f54bf14a7317cc9f5a71086a20964bea"
     end
     on_arm do
-      url "https://binaries.cockroachdb.com/cockroach-sql-v22.2.4.darwin-11.0-arm64.tgz"
-      sha256 "2476e54242d5177bfabe46a3dddaa66a963e94fa0643385583c9a00c51963968"
+      url "https://binaries.cockroachdb.com/cockroach-sql-v22.2.3.darwin-11.0-arm64.tgz"
+      sha256 "28ac8ad22a70f0d52ccaff189cac670103c3e8a7e01bb39f010d7398d3512c94"
     end
   end
 
@@ -22,7 +22,7 @@ class CockroachSql < Formula
 
   test do
     output = shell_output("#{bin}/cockroach-sql --version", 0)
-    assert_match "22.2.4", output
+    assert_match "22.2.3", output
   end
 
 end

--- a/Formula/cockroach-sql.rb
+++ b/Formula/cockroach-sql.rb
@@ -4,15 +4,15 @@
 class CockroachSql < Formula
   desc "Distributed SQL database shell"
   homepage "https://www.cockroachlabs.com"
-  version "23.1.0"
+  version "23.1.1"
   on_macos do
     on_intel do
-      url "https://binaries.cockroachdb.com/cockroach-sql-v23.1.0.darwin-10.9-amd64.tgz"
-      sha256 "42687b024f6dc0427f4754ce70e8dc7624f38d9e342781f8376722bb94c1da67"
+      url "https://binaries.cockroachdb.com/cockroach-sql-v23.1.1.darwin-10.9-amd64.tgz"
+      sha256 "386dc01e49bad96ac298b2d5a5285ed4e1b741df62c6e89691df5b5f2d0221d6"
     end
     on_arm do
-      url "https://binaries.cockroachdb.com/cockroach-sql-v23.1.0.darwin-11.0-arm64.tgz"
-      sha256 "85c24b7728fdfab795d6df9703ee81e3824ad473d0b89f5ac428d8ea7d3bfe14"
+      url "https://binaries.cockroachdb.com/cockroach-sql-v23.1.1.darwin-11.0-arm64.tgz"
+      sha256 "900d1e46bcb3f067e3fdb6ba38e1bd50a91fc4ef541d2145eb96490985dea485"
     end
   end
 
@@ -22,7 +22,7 @@ class CockroachSql < Formula
 
   test do
     output = shell_output("#{bin}/cockroach-sql --version", 0)
-    assert_match "23.1.0", output
+    assert_match "23.1.1", output
   end
 
 end

--- a/Formula/cockroach-sql.rb
+++ b/Formula/cockroach-sql.rb
@@ -4,15 +4,15 @@
 class CockroachSql < Formula
   desc "Distributed SQL database shell"
   homepage "https://www.cockroachlabs.com"
-  version "22.2.6"
+  version "22.2.7"
   on_macos do
     on_intel do
-      url "https://binaries.cockroachdb.com/cockroach-sql-v22.2.6.darwin-10.9-amd64.tgz"
-      sha256 "aaff0691ab9ee50d304cb4909a34bbea9eef1e216ab53457ba825f53e5bf7001"
+      url "https://binaries.cockroachdb.com/cockroach-sql-v22.2.7.darwin-10.9-amd64.tgz"
+      sha256 "b61943a3758b63e83c5a420ee5ca6aef5017260de26d55df46705bf12c67a08e"
     end
     on_arm do
-      url "https://binaries.cockroachdb.com/cockroach-sql-v22.2.6.darwin-11.0-arm64.tgz"
-      sha256 "4fccbef4c092f036a92a2bc82c265a0730baa86cc1cd3c8f59f7426491476afb"
+      url "https://binaries.cockroachdb.com/cockroach-sql-v22.2.7.darwin-11.0-arm64.tgz"
+      sha256 "5084703331848581114d4778338ad387e448eff7d62493db999097380ecbe34d"
     end
   end
 
@@ -22,7 +22,7 @@ class CockroachSql < Formula
 
   test do
     output = shell_output("#{bin}/cockroach-sql --version", 0)
-    assert_match "22.2.6", output
+    assert_match "22.2.7", output
   end
 
 end

--- a/Formula/cockroach.rb
+++ b/Formula/cockroach.rb
@@ -4,15 +4,15 @@
 class Cockroach < Formula
   desc "Distributed SQL database"
   homepage "https://www.cockroachlabs.com"
-  version "22.2.8"
+  version "22.2.9"
   on_macos do
     on_intel do
-      url "https://binaries.cockroachdb.com/cockroach-v22.2.8.darwin-10.9-amd64.tgz"
-      sha256 "7b007552ac902faa748da8cb7a935818075824922e601ea152ffaec01eccd107"
+      url "https://binaries.cockroachdb.com/cockroach-v22.2.9.darwin-10.9-amd64.tgz"
+      sha256 "33d07e2a8faf44890269a5a08b82942a7d8f00cc05fe1492253eccf139bfa25b"
     end
     on_arm do
-      url "https://binaries.cockroachdb.com/cockroach-v22.2.8.darwin-11.0-arm64.tgz"
-      sha256 "f7cadb97b3bd91e9cad02aa3fc5b67a6e6f6f41ffd5575f4879782ae878a3cd2"
+      url "https://binaries.cockroachdb.com/cockroach-v22.2.9.darwin-11.0-arm64.tgz"
+      sha256 "17d6a9809b3c94ec029fa961ea3a327177765f907f2d5d7e6412079dfda7f978"
     end
   end
 

--- a/Formula/cockroach.rb
+++ b/Formula/cockroach.rb
@@ -4,15 +4,15 @@
 class Cockroach < Formula
   desc "Distributed SQL database"
   homepage "https://www.cockroachlabs.com"
-  version "22.2.4"
+  version "22.2.3"
   on_macos do
     on_intel do
-      url "https://binaries.cockroachdb.com/cockroach-v22.2.4.darwin-10.9-amd64.tgz"
-      sha256 "69907de1218a44e46379f15b521cf5d8c80c040fcbafe61a682dd1782fb8a860"
+      url "https://binaries.cockroachdb.com/cockroach-v22.2.3.darwin-10.9-amd64.tgz"
+      sha256 "6df8416f1c9d6638d55d23e541f17d1bb38c03415313a43e1bb50ceb058996f1"
     end
     on_arm do
-      url "https://binaries.cockroachdb.com/cockroach-v22.2.4.darwin-11.0-arm64.tgz"
-      sha256 "272976a5a295564eacd286ab01e84fe5536828b93c14c427daca36e392bc8ff1"
+      url "https://binaries.cockroachdb.com/cockroach-v22.2.3.darwin-11.0-arm64.tgz"
+      sha256 "66ef3926143856f6e53525c932e635c84d803814ebbfdba222bc2d7afaa3d910"
     end
   end
 

--- a/Formula/cockroach.rb
+++ b/Formula/cockroach.rb
@@ -59,36 +59,12 @@ class Cockroach < Formula
   EOS
   end
 
-  plist_options :manual => "cockroach start-single-node --insecure --http-port=26256 --host=localhost"
-
-  def plist; <<~EOS
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-    <plist version="1.0">
-    <dict>
-      <key>Label</key>
-      <string>#{plist_name}</string>
-      <key>ProgramArguments</key>
-      <array>
-        <string>#{opt_bin}/cockroach</string>
-        <string>start-single-node</string>
-        <string>--store=#{var}/cockroach/</string>
-        <string>--spatial-libs=#{lib}/cockroach</string>
-        <string>--http-port=26256</string>
-        <string>--insecure</string>
-        <string>--host=localhost</string>
-      </array>
-      <key>WorkingDirectory</key>
-      <string>#{var}</string>
-      <key>RunAtLoad</key>
-      <true/>
-      <key>KeepAlive</key>
-      <true/>
-    </dict>
-    </plist>
-  EOS
+  service do
+    run [bin/"cockroach", "start-single-node", "--insecure", "--http-port=26256", "--host=localhost"]
+    keep_alive true
+    working_dir var
   end
-
+  
   test do
     begin
       # Redirect stdout and stderr to a file, or else  `brew test --verbose`

--- a/Formula/cockroach.rb
+++ b/Formula/cockroach.rb
@@ -4,15 +4,15 @@
 class Cockroach < Formula
   desc "Distributed SQL database"
   homepage "https://www.cockroachlabs.com"
-  version "23.1.1"
+  version "23.1.2"
   on_macos do
     on_intel do
-      url "https://binaries.cockroachdb.com/cockroach-v23.1.1.darwin-10.9-amd64.tgz"
-      sha256 "4faede4375045c9d7dcf7fd9cdeeebbf6905072e334c06751b77731564169e5c"
+      url "https://binaries.cockroachdb.com/cockroach-v23.1.2.darwin-10.9-amd64.tgz"
+      sha256 "ebc71d6a88170220437d0bad8d5de1df8b9af2f0857f222a5598f3c393ab817f"
     end
     on_arm do
-      url "https://binaries.cockroachdb.com/cockroach-v23.1.1.darwin-11.0-arm64.tgz"
-      sha256 "48e9f0540bf32e7be11a192a495be0dcb591f31b0095401fcd3bcbc65c21cfaa"
+      url "https://binaries.cockroachdb.com/cockroach-v23.1.2.darwin-11.0-arm64.tgz"
+      sha256 "a445d18da16aa4a083c8dbbdfa8afac40adaee503fd5c2d7da447d76016f5801"
     end
   end
 

--- a/Formula/cockroach.rb
+++ b/Formula/cockroach.rb
@@ -4,15 +4,15 @@
 class Cockroach < Formula
   desc "Distributed SQL database"
   homepage "https://www.cockroachlabs.com"
-  version "22.2.6"
+  version "22.2.7"
   on_macos do
     on_intel do
-      url "https://binaries.cockroachdb.com/cockroach-v22.2.6.darwin-10.9-amd64.tgz"
-      sha256 "a76ebf0e586613f21b38349087c0c139758f00176372096f9ebfc2b69068f0d8"
+      url "https://binaries.cockroachdb.com/cockroach-v22.2.7.darwin-10.9-amd64.tgz"
+      sha256 "87bdbd4f5eb43740ecffdc7e7919f35fb68adcbc302c85882d02655bbe4480fd"
     end
     on_arm do
-      url "https://binaries.cockroachdb.com/cockroach-v22.2.6.darwin-11.0-arm64.tgz"
-      sha256 "b944d2db942bf26002bb21d00a2640423fddbc3efba12160af1decea83a25e2b"
+      url "https://binaries.cockroachdb.com/cockroach-v22.2.7.darwin-11.0-arm64.tgz"
+      sha256 "1a9edb62164a676f066592f87b765dc5c31b70da89d5f9530078418b21e79be3"
     end
   end
 

--- a/Formula/cockroach.rb
+++ b/Formula/cockroach.rb
@@ -4,15 +4,15 @@
 class Cockroach < Formula
   desc "Distributed SQL database"
   homepage "https://www.cockroachlabs.com"
-  version "22.2.9"
+  version "23.1.0"
   on_macos do
     on_intel do
-      url "https://binaries.cockroachdb.com/cockroach-v22.2.9.darwin-10.9-amd64.tgz"
-      sha256 "33d07e2a8faf44890269a5a08b82942a7d8f00cc05fe1492253eccf139bfa25b"
+      url "https://binaries.cockroachdb.com/cockroach-v23.1.0.darwin-10.9-amd64.tgz"
+      sha256 "38e3fccd1e39deb794eed5e9d2c5ae47f0d8d2ec6b9bb1f1a1a3121a98c357b9"
     end
     on_arm do
-      url "https://binaries.cockroachdb.com/cockroach-v22.2.9.darwin-11.0-arm64.tgz"
-      sha256 "17d6a9809b3c94ec029fa961ea3a327177765f907f2d5d7e6412079dfda7f978"
+      url "https://binaries.cockroachdb.com/cockroach-v23.1.0.darwin-11.0-arm64.tgz"
+      sha256 "8357d92c698f02d3b9d2f933d81e643dc414545c68eab674d40cfccdc3168e11"
     end
   end
 

--- a/Formula/cockroach.rb
+++ b/Formula/cockroach.rb
@@ -4,15 +4,15 @@
 class Cockroach < Formula
   desc "Distributed SQL database"
   homepage "https://www.cockroachlabs.com"
-  version "22.2.7"
+  version "22.2.8"
   on_macos do
     on_intel do
-      url "https://binaries.cockroachdb.com/cockroach-v22.2.7.darwin-10.9-amd64.tgz"
-      sha256 "87bdbd4f5eb43740ecffdc7e7919f35fb68adcbc302c85882d02655bbe4480fd"
+      url "https://binaries.cockroachdb.com/cockroach-v22.2.8.darwin-10.9-amd64.tgz"
+      sha256 "7b007552ac902faa748da8cb7a935818075824922e601ea152ffaec01eccd107"
     end
     on_arm do
-      url "https://binaries.cockroachdb.com/cockroach-v22.2.7.darwin-11.0-arm64.tgz"
-      sha256 "1a9edb62164a676f066592f87b765dc5c31b70da89d5f9530078418b21e79be3"
+      url "https://binaries.cockroachdb.com/cockroach-v22.2.8.darwin-11.0-arm64.tgz"
+      sha256 "f7cadb97b3bd91e9cad02aa3fc5b67a6e6f6f41ffd5575f4879782ae878a3cd2"
     end
   end
 

--- a/Formula/cockroach.rb
+++ b/Formula/cockroach.rb
@@ -76,7 +76,7 @@ class Cockroach < Formula
     log_path var/"log/cockroach.log"
     error_log_path var/"log/cockroach.err"
   end
-  
+
   test do
     begin
       # Redirect stdout and stderr to a file, or else  `brew test --verbose`

--- a/Formula/cockroach.rb
+++ b/Formula/cockroach.rb
@@ -82,9 +82,9 @@ class Cockroach < Formula
       # Redirect stdout and stderr to a file, or else  `brew test --verbose`
       # will hang forever as it waits for stdout and stderr to close.
       pid = fork do
-        exec "#{bin}/cockroach start-single-node --insecure --background --listen-addr=127.0.0.1:0 --http-addr=127.0.0.1:0 --listening-url-file=listen_url_fifo&> start.out"
+        exec "#{bin}/cockroach start-single-node --insecure --background --listen-addr=127.0.0.1:0 --http-addr=127.0.0.1:0 --listening-url-file=listen_url_fifo &> start.out"
       end
-      sleep 2
+      sleep 8
 
       # TODO(bdarnell): remove the X from this variable and the --url flags after
       # https://github.com/cockroachdb/cockroach/issues/40747 is fixed.
@@ -100,12 +100,15 @@ class Cockroach < Formula
         id,balance
         1,1000.50
       EOS
-      output = pipe_output("#{bin}/cockroach sql --url=$XCOCKROACH_URL --format=csv",
-        "SELECT ST_IsValid(ST_MakePoint(1, 1)) is_valid;")
-      assert_equal <<~EOS, output
-        is_valid
-        true
-      EOS
+
+      if !(OS.mac? && Hardware::CPU.arm?)
+        output = pipe_output("#{bin}/cockroach sql --url=$XCOCKROACH_URL --format=csv",
+          "SELECT ST_IsValid(ST_MakePoint(1, 1)) is_valid;")
+        assert_equal <<~EOS, output
+          is_valid
+          t
+        EOS
+      end
     rescue => e
       # If an error occurs, attempt to print out any messages from the
       # server.

--- a/Formula/cockroach.rb
+++ b/Formula/cockroach.rb
@@ -4,15 +4,15 @@
 class Cockroach < Formula
   desc "Distributed SQL database"
   homepage "https://www.cockroachlabs.com"
-  version "22.2.5"
+  version "22.2.6"
   on_macos do
     on_intel do
-      url "https://binaries.cockroachdb.com/cockroach-v22.2.5.darwin-10.9-amd64.tgz"
-      sha256 "d9cc314534c46c065f0b92e5b0cf8b0e9c8a1fa5f2dcd2dae0b931e7fa97ff8c"
+      url "https://binaries.cockroachdb.com/cockroach-v22.2.6.darwin-10.9-amd64.tgz"
+      sha256 "a76ebf0e586613f21b38349087c0c139758f00176372096f9ebfc2b69068f0d8"
     end
     on_arm do
-      url "https://binaries.cockroachdb.com/cockroach-v22.2.5.darwin-11.0-arm64.tgz"
-      sha256 "c008b6ee57eaf7b8ef1f1df277e1a3cbcfb0a9580eed3f840a9edd486fa387d0"
+      url "https://binaries.cockroachdb.com/cockroach-v22.2.6.darwin-11.0-arm64.tgz"
+      sha256 "b944d2db942bf26002bb21d00a2640423fddbc3efba12160af1decea83a25e2b"
     end
   end
 
@@ -100,7 +100,6 @@ class Cockroach < Formula
         id,balance
         1,1000.50
       EOS
-
       if !(OS.mac? && Hardware::CPU.arm?)
         output = pipe_output("#{bin}/cockroach sql --url=$XCOCKROACH_URL --format=csv",
           "SELECT ST_IsValid(ST_MakePoint(1, 1)) is_valid;")
@@ -124,3 +123,4 @@ class Cockroach < Formula
     end
   end
 end
+

--- a/Formula/cockroach.rb
+++ b/Formula/cockroach.rb
@@ -4,15 +4,15 @@
 class Cockroach < Formula
   desc "Distributed SQL database"
   homepage "https://www.cockroachlabs.com"
-  version "22.2.3"
+  version "22.2.4"
   on_macos do
     on_intel do
-      url "https://binaries.cockroachdb.com/cockroach-v22.2.3.darwin-10.9-amd64.tgz"
-      sha256 "6df8416f1c9d6638d55d23e541f17d1bb38c03415313a43e1bb50ceb058996f1"
+      url "https://binaries.cockroachdb.com/cockroach-v22.2.4.darwin-10.9-amd64.tgz"
+      sha256 "69907de1218a44e46379f15b521cf5d8c80c040fcbafe61a682dd1782fb8a860"
     end
     on_arm do
-      url "https://binaries.cockroachdb.com/cockroach-v22.2.3.darwin-11.0-arm64.tgz"
-      sha256 "66ef3926143856f6e53525c932e635c84d803814ebbfdba222bc2d7afaa3d910"
+      url "https://binaries.cockroachdb.com/cockroach-v22.2.4.darwin-11.0-arm64.tgz"
+      sha256 "272976a5a295564eacd286ab01e84fe5536828b93c14c427daca36e392bc8ff1"
     end
   end
 

--- a/Formula/cockroach.rb
+++ b/Formula/cockroach.rb
@@ -60,9 +60,21 @@ class Cockroach < Formula
   end
 
   service do
-    run [bin/"cockroach", "start-single-node", "--insecure", "--http-port=26256", "--host=localhost"]
-    keep_alive true
+    args = [
+      "start-single-node",
+      "--store=#{var}/cockroach",
+      "--http-port=26256",
+      "--insecure",
+      "--host=localhost",
+     ]
+    if !(OS.mac? && Hardware::CPU.arm?)
+      args << "--spatial-libs=#{opt_bin}/../lib/cockroach"
+    end
+    run [opt_bin/"cockroach"] + args
     working_dir var
+    keep_alive true
+    log_path var/"log/cockroach.log"
+    error_log_path var/"log/cockroach.err"
   end
   
   test do
@@ -109,4 +121,3 @@ class Cockroach < Formula
     end
   end
 end
-

--- a/Formula/cockroach.rb
+++ b/Formula/cockroach.rb
@@ -4,15 +4,15 @@
 class Cockroach < Formula
   desc "Distributed SQL database"
   homepage "https://www.cockroachlabs.com"
-  version "23.1.0"
+  version "23.1.1"
   on_macos do
     on_intel do
-      url "https://binaries.cockroachdb.com/cockroach-v23.1.0.darwin-10.9-amd64.tgz"
-      sha256 "38e3fccd1e39deb794eed5e9d2c5ae47f0d8d2ec6b9bb1f1a1a3121a98c357b9"
+      url "https://binaries.cockroachdb.com/cockroach-v23.1.1.darwin-10.9-amd64.tgz"
+      sha256 "4faede4375045c9d7dcf7fd9cdeeebbf6905072e334c06751b77731564169e5c"
     end
     on_arm do
-      url "https://binaries.cockroachdb.com/cockroach-v23.1.0.darwin-11.0-arm64.tgz"
-      sha256 "8357d92c698f02d3b9d2f933d81e643dc414545c68eab674d40cfccdc3168e11"
+      url "https://binaries.cockroachdb.com/cockroach-v23.1.1.darwin-11.0-arm64.tgz"
+      sha256 "48e9f0540bf32e7be11a192a495be0dcb591f31b0095401fcd3bcbc65c21cfaa"
     end
   end
 

--- a/Formula/cockroach.rb
+++ b/Formula/cockroach.rb
@@ -4,15 +4,15 @@
 class Cockroach < Formula
   desc "Distributed SQL database"
   homepage "https://www.cockroachlabs.com"
-  version "23.1.2"
+  version "23.1.3"
   on_macos do
     on_intel do
-      url "https://binaries.cockroachdb.com/cockroach-v23.1.2.darwin-10.9-amd64.tgz"
-      sha256 "ebc71d6a88170220437d0bad8d5de1df8b9af2f0857f222a5598f3c393ab817f"
+      url "https://binaries.cockroachdb.com/cockroach-v23.1.3.darwin-10.9-amd64.tgz"
+      sha256 "d312bef12dac81bdde7d37db4653c6b961c931e55fc9efd54485f79908250b06"
     end
     on_arm do
-      url "https://binaries.cockroachdb.com/cockroach-v23.1.2.darwin-11.0-arm64.tgz"
-      sha256 "a445d18da16aa4a083c8dbbdfa8afac40adaee503fd5c2d7da447d76016f5801"
+      url "https://binaries.cockroachdb.com/cockroach-v23.1.3.darwin-11.0-arm64.tgz"
+      sha256 "7282e72df0345b40b5d2165df7050dcdb8cc179bf8513c9f0ce92d61484aa8c3"
     end
   end
 

--- a/Formula/cockroach.rb
+++ b/Formula/cockroach.rb
@@ -4,15 +4,15 @@
 class Cockroach < Formula
   desc "Distributed SQL database"
   homepage "https://www.cockroachlabs.com"
-  version "22.2.3"
+  version "22.2.5"
   on_macos do
     on_intel do
-      url "https://binaries.cockroachdb.com/cockroach-v22.2.3.darwin-10.9-amd64.tgz"
-      sha256 "6df8416f1c9d6638d55d23e541f17d1bb38c03415313a43e1bb50ceb058996f1"
+      url "https://binaries.cockroachdb.com/cockroach-v22.2.5.darwin-10.9-amd64.tgz"
+      sha256 "d9cc314534c46c065f0b92e5b0cf8b0e9c8a1fa5f2dcd2dae0b931e7fa97ff8c"
     end
     on_arm do
-      url "https://binaries.cockroachdb.com/cockroach-v22.2.3.darwin-11.0-arm64.tgz"
-      sha256 "66ef3926143856f6e53525c932e635c84d803814ebbfdba222bc2d7afaa3d910"
+      url "https://binaries.cockroachdb.com/cockroach-v22.2.5.darwin-11.0-arm64.tgz"
+      sha256 "c008b6ee57eaf7b8ef1f1df277e1a3cbcfb0a9580eed3f840a9edd486fa387d0"
     end
   end
 

--- a/Formula/cockroach.rb
+++ b/Formula/cockroach.rb
@@ -4,15 +4,15 @@
 class Cockroach < Formula
   desc "Distributed SQL database"
   homepage "https://www.cockroachlabs.com"
-  version "23.1.3"
+  version "23.1.4"
   on_macos do
     on_intel do
-      url "https://binaries.cockroachdb.com/cockroach-v23.1.3.darwin-10.9-amd64.tgz"
-      sha256 "d312bef12dac81bdde7d37db4653c6b961c931e55fc9efd54485f79908250b06"
+      url "https://binaries.cockroachdb.com/cockroach-v23.1.4.darwin-10.9-amd64.tgz"
+      sha256 "019452db12dbef985f16fa958c44d679aa81c7e7826aa7e03cbfbb76c95c8844"
     end
     on_arm do
-      url "https://binaries.cockroachdb.com/cockroach-v23.1.3.darwin-11.0-arm64.tgz"
-      sha256 "7282e72df0345b40b5d2165df7050dcdb8cc179bf8513c9f0ce92d61484aa8c3"
+      url "https://binaries.cockroachdb.com/cockroach-v23.1.4.darwin-11.0-arm64.tgz"
+      sha256 "d0a136d159fba61aa7b90ba37ad757b3f016996302f6c8d55b2cd3e3aa60f481"
     end
   end
 

--- a/Formula/cockroach.rb
+++ b/Formula/cockroach.rb
@@ -84,7 +84,7 @@ class Cockroach < Formula
       pid = fork do
         exec "#{bin}/cockroach start-single-node --insecure --background --listen-addr=127.0.0.1:0 --http-addr=127.0.0.1:0 --listening-url-file=listen_url_fifo &> start.out"
       end
-      sleep 8
+      sleep 20
 
       # TODO(bdarnell): remove the X from this variable and the --url flags after
       # https://github.com/cockroachdb/cockroach/issues/40747 is fixed.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # CockroachDB Homebrew Tap
 
-This is the official source for installing CockroachDB and the CockroachDB Cloud CLI with Homebrew.
+This is the official source for installing CockroachDB, CockroachDB SQL CLI, and the CockroachDB Cloud CLI with Homebrew.
 
 ## Installing
 
 ```shell
 $ brew install cockroachdb/tap/cockroach
+$ brew install cockroachdb/tap/cockroach-sql
 $ brew install cockroachdb/tap/ccloud
 ```
 
@@ -14,6 +15,7 @@ Alternately, you can configure the tap and install the package separately:
 ``` shell
 $ brew tap cockroachdb/tap
 $ brew install cockroach
+$ brew install cockroach-sql
 $ brew install ccloud
 ```
 

--- a/release/ccloud-tmpl.rb
+++ b/release/ccloud-tmpl.rb
@@ -5,8 +5,17 @@ class Ccloud < Formula
   desc "CockroachDB Cloud CLI"
   homepage "https://www.cockroachlabs.com"
   version "{{ .Version }}"
-  url "{{ .IntelURL }}"
-  sha256 "{{ .IntelSHA256 }}"
+
+  on_macos do
+    on_intel do
+      url "{{ .IntelURL }}"
+      sha256 "{{ .IntelSHA256 }}"
+    end
+    on_arm do
+      url "{{ .ARMURL }}"
+      sha256 "{{ .ARMSHA256 }}"
+    end
+  end
 
   def install
     bin.install "ccloud"

--- a/release/cockroach-tmpl.rb
+++ b/release/cockroach-tmpl.rb
@@ -82,9 +82,9 @@ class Cockroach < Formula
       # Redirect stdout and stderr to a file, or else  `brew test --verbose`
       # will hang forever as it waits for stdout and stderr to close.
       pid = fork do
-        exec "#{bin}/cockroach start-single-node --insecure --background --listen-addr=127.0.0.1:0 --http-addr=127.0.0.1:0 --listening-url-file=listen_url_fifo&> start.out"
+        exec "#{bin}/cockroach start-single-node --insecure --background --listen-addr=127.0.0.1:0 --http-addr=127.0.0.1:0 --listening-url-file=listen_url_fifo &> start.out"
       end
-      sleep 2
+      sleep 8
 
       # TODO(bdarnell): remove the X from this variable and the --url flags after
       # https://github.com/cockroachdb/cockroach/issues/40747 is fixed.
@@ -100,12 +100,14 @@ class Cockroach < Formula
         id,balance
         1,1000.50
       EOS
-      output = pipe_output("#{bin}/cockroach sql --url=$XCOCKROACH_URL --format=csv",
-        "SELECT ST_IsValid(ST_MakePoint(1, 1)) is_valid;")
-      assert_equal <<~EOS, output
-        is_valid
-        true
-      EOS
+      if !(OS.mac? && Hardware::CPU.arm?)
+        output = pipe_output("#{bin}/cockroach sql --url=$XCOCKROACH_URL --format=csv",
+          "SELECT ST_IsValid(ST_MakePoint(1, 1)) is_valid;")
+        assert_equal <<~EOS, output
+          is_valid
+          t
+        EOS
+      end
     rescue => e
       # If an error occurs, attempt to print out any messages from the
       # server.

--- a/release/cockroach-tmpl.rb
+++ b/release/cockroach-tmpl.rb
@@ -59,34 +59,22 @@ class Cockroach < Formula
   EOS
   end
 
-  plist_options :manual => "cockroach start-single-node --insecure --http-port=26256 --host=localhost"
-
-  def plist; <<~EOS
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-    <plist version="1.0">
-    <dict>
-      <key>Label</key>
-      <string>#{plist_name}</string>
-      <key>ProgramArguments</key>
-      <array>
-        <string>#{opt_bin}/cockroach</string>
-        <string>start-single-node</string>
-        <string>--store=#{var}/cockroach/</string>
-        <string>--spatial-libs=#{lib}/cockroach</string>
-        <string>--http-port=26256</string>
-        <string>--insecure</string>
-        <string>--host=localhost</string>
-      </array>
-      <key>WorkingDirectory</key>
-      <string>#{var}</string>
-      <key>RunAtLoad</key>
-      <true/>
-      <key>KeepAlive</key>
-      <true/>
-    </dict>
-    </plist>
-  EOS
+  service do
+    args = [
+      "start-single-node",
+      "--store=#{var}/cockroach",
+      "--http-port=26256",
+      "--insecure",
+      "--host=localhost",
+     ]
+    if !(OS.mac? && Hardware::CPU.arm?)
+      args << "--spatial-libs=#{opt_bin}/../lib/cockroach"
+    end
+    run [opt_bin/"cockroach"] + args
+    working_dir var
+    keep_alive true
+    log_path var/"log/cockroach.log"
+    error_log_path var/"log/cockroach.err"
   end
 
   test do

--- a/release/cockroach-tmpl.rb
+++ b/release/cockroach-tmpl.rb
@@ -84,7 +84,7 @@ class Cockroach < Formula
       pid = fork do
         exec "#{bin}/cockroach start-single-node --insecure --background --listen-addr=127.0.0.1:0 --http-addr=127.0.0.1:0 --listening-url-file=listen_url_fifo &> start.out"
       end
-      sleep 8
+      sleep 20
 
       # TODO(bdarnell): remove the X from this variable and the --url flags after
       # https://github.com/cockroachdb/cockroach/issues/40747 is fixed.

--- a/release/main.go
+++ b/release/main.go
@@ -18,7 +18,8 @@ const (
 	ccloud            = "ccloud"
 	cockroachURLIntel = "https://binaries.cockroachdb.com/%s-v%s.darwin-10.9-amd64.tgz"
 	cockroachURLARM   = "https://binaries.cockroachdb.com/%s-v%s.darwin-11.0-arm64.tgz"
-	ccloudURL         = "https://binaries.cockroachdb.com/ccloud/ccloud_darwin-amd64_%s.tar.gz"
+	ccloudURLIntel    = "https://binaries.cockroachdb.com/ccloud/ccloud_darwin-amd64_%s.tar.gz"
+	ccloudURLARM      = "https://binaries.cockroachdb.com/ccloud/ccloud_darwin-arm64_%s.tar.gz"
 )
 
 type templateArgs struct {
@@ -86,13 +87,21 @@ func processTemplate(product, version string, templateFile string) (string, erro
 		data.ARMURL = urlARM
 		data.ARMSHA256 = sha256ARM
 	} else if product == ccloud {
-		url := fmt.Sprintf(ccloudURL, version)
+		url := fmt.Sprintf(ccloudURLIntel, version)
 		sha256, err := sha256FromURL(url)
 		if err != nil {
 			return "", fmt.Errorf("failed to calculate SHA256: %w", err)
 		}
 		data.IntelURL = url
 		data.IntelSHA256 = sha256
+
+		urlARM := fmt.Sprintf(ccloudURLARM, version)
+		sha256ARM, err := sha256FromURL(urlARM)
+		if err != nil {
+			return "", fmt.Errorf("failed to calculate SHA256: %w", err)
+		}
+		data.ARMURL = urlARM
+		data.ARMSHA256 = sha256ARM
 	}
 	var buf bytes.Buffer
 	err = t.Execute(&buf, data)


### PR DESCRIPTION
I confirmed locally that the cockroach service is started with the correct `--store=type=mem,size=8GB` parameter _and_ that a local `bin/environmentd` works against it.

Plus, this get's rid of an annoying homebrew warning about `plist_options` that would show up whenever running any `brew` command (upstream fixed this by removing usage of that deprecated feature).